### PR TITLE
fix: never publish empty newspapers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install
-      - run: bunx tsc --noEmit 2>/dev/null || true
+      - run: bunx tsc --noEmit
+      - run: bun test

--- a/DISPATCH_SPEC.md
+++ b/DISPATCH_SPEC.md
@@ -32,7 +32,9 @@ See also: `../gitzette-dispatch/EDITORIAL.md` — the offline script's editorial
 - Fetch `/users/{username}/repos?per_page=100&sort=pushed`, take first 30 (**include forks**).
 - For forks: pass `author={username}` on commits query (skip upstream merges), skip releases/PRs (those belong to upstream).
 - Also run `/search/issues?q=author:{username}+is:pr+created:{from}..{to}` to catch **external contributions** (e.g. NikolayS's PRs to pgdogdev/pgdog, rust-postgres/rust-postgres, postgres-ai/*). External repos are shown with PR data only, no commits/releases.
-- Quiet weeks (0 active repos) save a `<p>No activity this week.</p>` placeholder; no illustrations generated.
+- Quiet weeks (0 active repos) publish a designed, deterministic “quiet week” edition with zeroed stats and an inline ink illustration. Never store a bare placeholder.
+- A total repository-scan failure is not a quiet week: abort generation and preserve the previous dispatch.
+- Legacy bare placeholders are upgraded at read time by `pages.ts` so old links remain useful without an R2 migration.
 
 ## README screenshots
 
@@ -73,7 +75,7 @@ Must require: Victorian-era woodcut engraving, centered object occupying **~60% 
 Enforced in code — do not relax without testing:
 
 - `targetImageCount = clamp(2, round(articles.length * 0.4), 3)`
-- **Always at least 2 AI illustrations** — they're the visual identity. `minAiCount = 2`. Set by user as non-negotiable.
+- **Always at least 2 AI illustrations for activity editions** — they're the visual identity. `minAiCount = 2`. Set by user as non-negotiable. Quiet-week editions use one deterministic inline illustration and do not call image generation.
 - `maxScreenshots = max(0, targetImageCount - minAiCount)` (so README screenshots never absorb the whole budget).
 - **Image is per-article, not per-repo.** LLM may legitimately write 5 articles for the same repo (e.g. levkk on pgdog). Pre-fix, all 5 shared one illustration. Store the URL on the article object as `a._img` and `a._isIllustration`.
 - **Dedupe URLs across the dispatch.** If `generateIllustration` returns the same slug as another article (same illustrationPrompt), skip it — no two articles show the same pic.
@@ -144,4 +146,5 @@ All three functions (`pages.ts:currentWeekKey`, `generate.ts:weekKey/isoWeekKeyA
 - `shape-outside: circle()`, not `url()`. Not negotiable for woodcut style.
 - At least 2 AI illustrations per dispatch, always.
 - Unique URLs across every dispatch — dedupe at selection time and at generation time.
+- Never publish article-free HTML. Validate LLM articles and the final document before writing to R2.
 - Test changes by actually regenerating at least 2 users with different profile shapes (a quiet one like DHH, a busy one like simonw) and viewing the output. CSS changes require regeneration to take effect — the CSS is inlined in the R2 HTML.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241106.0",
+        "typescript": "^5.9.3",
         "wrangler": "4",
       },
     },
@@ -181,6 +182,8 @@
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "db:init": "wrangler d1 execute gitzette-db --remote --file=schema.sql"
+    "db:init": "wrangler d1 execute gitzette-db --remote --file=schema.sql",
+    "test": "bun test"
   },
   "dependencies": {
     "hono": "^4.6.0"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -91,6 +91,6 @@ export async function getUser(c: any): Promise<{ id: string; username: string; a
     `SELECT u.id, u.username, u.avatar_url FROM sessions s
      JOIN users u ON u.id = s.user_id
      WHERE s.token = ? AND s.expires_at > ?`
-  ).bind(token, now).first<{ id: string; username: string; avatar_url: string }>();
+  ).bind(token, now).first() as { id: string; username: string; avatar_url: string } | null;
   return row ?? null;
 }

--- a/src/dispatch-health.test.ts
+++ b/src/dispatch-health.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { isLegacyEmptyDispatch, slowNewsCopy, slowNewsFragment } from "./dispatch-health";
+import { assertPublishableDispatch, validateGeneratedCopy } from "./generate";
+
+describe("empty dispatch recovery", () => {
+  test("recognizes both legacy empty payloads", () => {
+    expect(isLegacyEmptyDispatch("<p>No activity this week.</p>")).toBe(true);
+    expect(isLegacyEmptyDispatch("  <p>No public repos found.</p>\n")).toBe(true);
+    expect(isLegacyEmptyDispatch("<p>A real article.</p>")).toBe(false);
+  });
+
+  test("builds a useful slow-news edition", () => {
+    const copy = slowNewsCopy("octocat");
+    expect(copy.articles).toHaveLength(1);
+    expect(copy.articles[0].headline).toContain("Moment of Silence");
+    expect(copy.articles[0].deck).toContain("@octocat");
+    expect(slowNewsFragment("octocat")).toContain("The presses remain ready");
+  });
+});
+
+describe("publication guard", () => {
+  const repo = {
+    name: "widget",
+    description: null,
+    url: "https://github.com/octocat/widget",
+    stars: 0,
+    releases: [],
+    mergedPRs: [],
+    openPRs: [],
+    commitCount: 1,
+    demoImages: [],
+  };
+
+  test("rejects empty or unknown LLM articles", () => {
+    expect(() => validateGeneratedCopy({ articles: [] }, [repo])).toThrow("no publishable articles");
+    expect(() => validateGeneratedCopy({ articles: [{ repo: "invented", headline: "x", body: "y" }] }, [repo]))
+      .toThrow("no publishable articles");
+  });
+
+  test("keeps valid articles and drops hallucinated repos", () => {
+    const result = validateGeneratedCopy({ articles: [
+      { repo: "invented", headline: "x", body: "y" },
+      { repo: "widget", headline: "Widget ships", body: "One commit landed." },
+    ] }, [repo]);
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].repo).toBe("widget");
+  });
+
+  test("refuses article-free HTML", () => {
+    expect(() => assertPublishableDispatch("<p>No activity this week.</p>"))
+      .toThrow("without an article");
+    expect(() => assertPublishableDispatch("<h2>Headline</h2><p>Body</p>"))
+      .not.toThrow();
+  });
+});

--- a/src/dispatch-health.ts
+++ b/src/dispatch-health.ts
@@ -1,0 +1,37 @@
+const LEGACY_EMPTY_DISPATCHES = new Set([
+  "<p>no activity this week.</p>",
+  "<p>no public repos found.</p>",
+]);
+
+export function isLegacyEmptyDispatch(html: string): boolean {
+  return LEGACY_EMPTY_DISPATCHES.has(html.trim().toLowerCase());
+}
+
+export function slowNewsCopy(username: string) {
+  return {
+    masthead: "the dispatch",
+    tagline: "A quiet week on the commit front.",
+    editionNote: "Zero commits, zero emergencies, and no release notes requiring archaeological work.",
+    articles: [{
+      repo: "__slow_news__",
+      headline: "The Repositories Observe a Moment of Silence",
+      deck: `No public commits, pull requests, or releases from @${username} made this edition.`,
+      body: `<svg viewBox="0 0 360 150" role="img" aria-label="A quiet desk with a closed laptop" style="float:right;width:min(42%,180px);height:auto;margin:0 0 12px 18px" xmlns="http://www.w3.org/2000/svg"><g fill="none" stroke="currentColor" stroke-width="3"><path d="M50 115h260M105 98h150l22 17H83zM120 35h120v63H120zM130 45h100v43H130zM45 72h42v43H45zM54 62h24M62 52h8"/><path d="M145 66h70M180 45v43" stroke-width="1"/></g></svg>The public record shows a slow news week. That is not an error and, by software standards, may even qualify as good news. The presses remain ready for the next push.`,
+      tag: "QUIET WEEK",
+      illustrationPrompt: "",
+    }],
+    closingNote: "No diffs were harmed in the making of this edition.",
+  };
+}
+
+export function slowNewsFragment(username: string): string {
+  const copy = slowNewsCopy(username);
+  const article = copy.articles[0];
+  return `<section style="max-width:760px;margin:0 auto;padding:48px 24px 64px;">
+    <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;margin-bottom:12px;">${article.tag}</div>
+    <h1 style="font-family:'Playfair Display',Georgia,serif;font-size:clamp(32px,8vw,64px);line-height:1.02;margin-bottom:14px;">${article.headline}</h1>
+    <p style="font-family:Georgia,serif;font-size:18px;font-style:italic;color:#666;margin-bottom:28px;">${article.deck}</p>
+    <div style="font-family:Georgia,serif;font-size:17px;line-height:1.7;">${article.body}</div>
+    <div style="clear:both;border-top:1px solid #c8c2b4;margin-top:32px;padding-top:12px;font-family:'IBM Plex Mono',monospace;font-size:11px;color:#666;">${copy.closingNote}</div>
+  </section>`;
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { getUser } from "./auth";
 import { checkUserQuota, checkGlobalBudget, recordSpend, recordGeneration } from "./quota";
+import { slowNewsCopy } from "./dispatch-health";
 import type { Env } from "./index";
 
 export const generateRoutes = new Hono<{ Bindings: Env }>();
@@ -22,6 +23,7 @@ generateRoutes.post("/", async (c) => {
   // Admin mode: NikolayS can generate dispatches for any GitHub user
   let target: { id: string; username: string } = user;
   const isAdmin = user.username === "NikolayS";
+  const shouldRecordUsage = !(forUsername && isAdmin);
   if (forUsername && isAdmin) {
     // Look up or create the target user in D1
     let row = await c.env.DB.prepare(
@@ -62,13 +64,16 @@ generateRoutes.post("/", async (c) => {
         sponsor_url: "https://github.com/sponsors/NikolayS",
       }, 503);
     }
-    await recordGeneration(c.env.DB, user.id);
-    await recordSpend(c.env.DB, 0.10);
   }
 
   // run generation synchronously (waitUntil gets killed too early for Opus + illustrations)
   try {
-    await runGeneration(c.env, target, targetWeek);
+    const generationCost = await runGeneration(c.env, target, targetWeek);
+    if (shouldRecordUsage) {
+      // Failed generations should not consume quota or budget.
+      await recordGeneration(c.env.DB, user.id);
+      await recordSpend(c.env.DB, generationCost);
+    }
     return c.json({ status: "ready", message: `Dispatch generated for @${target.username}.`, username: target.username });
   } catch (err) {
     console.error(`generation failed for ${target.username}:`, err);
@@ -116,6 +121,32 @@ interface RepoData {
   commitCount: number; demoImages: string[];
 }
 
+export function validateGeneratedCopy(copy: any, reposData: RepoData[]): any {
+  if (!copy || !Array.isArray(copy.articles)) {
+    throw new Error("LLM response has no articles array");
+  }
+
+  const knownRepos = new Set(reposData.map(repo => repo.name));
+  const validArticles = copy.articles.filter((article: any) =>
+    article &&
+    knownRepos.has(article.repo) &&
+    typeof article.headline === "string" && article.headline.trim().length > 0 &&
+    typeof article.body === "string" && article.body.trim().length > 0
+  );
+
+  if (validArticles.length === 0) {
+    throw new Error("LLM response has no publishable articles");
+  }
+
+  return { ...copy, articles: validArticles };
+}
+
+export function assertPublishableDispatch(html: string): void {
+  if (!/<h2\b[^>]*>[\s\S]*?<\/h2>/i.test(html) || !/<p\b[^>]*>[\s\S]*?<\/p>/i.test(html)) {
+    throw new Error("refusing to publish a dispatch without an article");
+  }
+}
+
 // ── github api ────────────────────────────────────────────────────────────────
 
 async function ghGet(path: string, token: string): Promise<any> {
@@ -158,52 +189,49 @@ async function getReadmeImages(owner: string, repo: string, token: string, newsp
 }
 
 async function getRepoData(owner: string, repo: string, from: Date, to: Date, token: string, newspaperifyUrl: string, secret: string, isFork: boolean = false, authorFilter?: string): Promise<RepoData | null> {
-  try {
-    const info = await ghGet(`/repos/${owner}/${repo}`, token);
+  // Repository metadata is mandatory. Optional GitHub features may return
+  // 404/409, so their failures must not discard otherwise valid activity.
+  const info = await ghGet(`/repos/${owner}/${repo}`, token);
 
-    // For forks, skip releases/PRs (those belong to upstream) and only count user's commits
-    let releases: Release[] = [];
-    let mergedPRs: PR[] = [];
-    let openPRs: PR[] = [];
+  // For forks, skip releases/PRs (those belong to upstream) and only count user's commits
+  let releases: Release[] = [];
+  let mergedPRs: PR[] = [];
+  let openPRs: PR[] = [];
 
-    if (!isFork) {
-      const allReleases = await ghGet(`/repos/${owner}/${repo}/releases?per_page=20`, token);
-      releases = allReleases
-        .filter((r: any) => { const d = new Date(r.published_at); return d >= from && d <= to; })
-        .map((r: any) => ({ tag: r.tag_name, name: r.name || r.tag_name, date: r.published_at, body: (r.body || "").slice(0, 2000), url: r.html_url }));
+  if (!isFork) {
+    const allReleases = await ghGet(`/repos/${owner}/${repo}/releases?per_page=20`, token).catch(() => []);
+    releases = allReleases
+      .filter((r: any) => { const d = new Date(r.published_at); return d >= from && d <= to; })
+      .map((r: any) => ({ tag: r.tag_name, name: r.name || r.tag_name, date: r.published_at, body: (r.body || "").slice(0, 2000), url: r.html_url }));
 
-      const allPRs = await ghGet(`/repos/${owner}/${repo}/pulls?state=closed&per_page=50&sort=updated&direction=desc`, token);
-      mergedPRs = allPRs
-        .filter((p: any) => { if (!p.merged_at) return false; const d = new Date(p.merged_at); return d >= from && d <= to; })
-        .map((p: any) => ({ number: p.number, title: p.title, state: "merged" as const, date: p.merged_at, url: p.html_url, author: p.user?.login || "unknown" }));
+    const allPRs = await ghGet(`/repos/${owner}/${repo}/pulls?state=closed&per_page=50&sort=updated&direction=desc`, token).catch(() => []);
+    mergedPRs = allPRs
+      .filter((p: any) => { if (!p.merged_at) return false; const d = new Date(p.merged_at); return d >= from && d <= to; })
+      .map((p: any) => ({ number: p.number, title: p.title, state: "merged" as const, date: p.merged_at, url: p.html_url, author: p.user?.login || "unknown" }));
 
-      const openPRsRaw = await ghGet(`/repos/${owner}/${repo}/pulls?state=open&per_page=50&sort=created&direction=desc`, token);
-      openPRs = openPRsRaw
-        .filter((p: any) => { const d = new Date(p.created_at); return d >= from && d <= to; })
-        .map((p: any) => ({ number: p.number, title: p.title, state: "open" as const, date: p.created_at, url: p.html_url, author: p.user?.login || "unknown" }));
-    }
-
-    let commitCount = 0;
-    try {
-      // For forks, filter by author so we only count the user's own commits (not upstream merges)
-      const authorParam = authorFilter ? `&author=${encodeURIComponent(authorFilter)}` : "";
-      const commits = await ghGet(`/repos/${owner}/${repo}/commits?since=${from.toISOString()}&until=${to.toISOString()}&per_page=100${authorParam}`, token);
-      commitCount = Array.isArray(commits) ? commits.length : 0;
-    } catch { /* empty repo */ }
-
-    if (releases.length === 0 && mergedPRs.length === 0 && openPRs.length === 0 && commitCount === 0) return null;
-
-    // Fetch README screenshot (for own non-fork repos) — real screenshots preferred over AI illustrations
-    let demoImages: string[] = [];
-    if (!isFork) {
-      try { demoImages = await getReadmeImages(owner, repo, token, newspaperifyUrl, secret); } catch {}
-    }
-
-    return { name: repo, description: info.description, url: info.html_url, stars: info.stargazers_count ?? 0, releases, mergedPRs, openPRs, commitCount, demoImages };
-  } catch (err) {
-    console.error(`skipping ${repo}:`, err);
-    return null;
+    const openPRsRaw = await ghGet(`/repos/${owner}/${repo}/pulls?state=open&per_page=50&sort=created&direction=desc`, token).catch(() => []);
+    openPRs = openPRsRaw
+      .filter((p: any) => { const d = new Date(p.created_at); return d >= from && d <= to; })
+      .map((p: any) => ({ number: p.number, title: p.title, state: "open" as const, date: p.created_at, url: p.html_url, author: p.user?.login || "unknown" }));
   }
+
+  let commitCount = 0;
+  try {
+    // Filter by author when requested so forks do not inherit upstream activity.
+    const authorParam = authorFilter ? `&author=${encodeURIComponent(authorFilter)}` : "";
+    const commits = await ghGet(`/repos/${owner}/${repo}/commits?since=${from.toISOString()}&until=${to.toISOString()}&per_page=100${authorParam}`, token);
+    commitCount = Array.isArray(commits) ? commits.length : 0;
+  } catch { /* empty repo */ }
+
+  if (releases.length === 0 && mergedPRs.length === 0 && openPRs.length === 0 && commitCount === 0) return null;
+
+  // Fetch README screenshot (for own non-fork repos) — real screenshots preferred over AI illustrations
+  let demoImages: string[] = [];
+  if (!isFork) {
+    try { demoImages = await getReadmeImages(owner, repo, token, newspaperifyUrl, secret); } catch {}
+  }
+
+  return { name: repo, description: info.description, url: info.html_url, stars: info.stargazers_count ?? 0, releases, mergedPRs, openPRs, commitCount, demoImages };
 }
 
 // ── image generation ──────────────────────────────────────────────────────────
@@ -623,7 +651,9 @@ async function runGeneration(env: Env, user: { id: string; username: string }, t
     from = new Date(mon1);
     from.setUTCDate(mon1.getUTCDate() + (w - 1) * 7);
     to = new Date(from);
-    to.setUTCDate(from.getUTCDate() + 7);
+    // Keep the endpoint inside the requested ISO week. Using next Monday made
+    // regeneration of W15 get saved under W16.
+    to.setTime(from.getTime() + 7 * 86400000 - 1);
   } else {
     to = new Date();
     // Snap from= to Monday 00:00 AoE (= Monday 12:00 UTC)
@@ -646,14 +676,9 @@ async function runGeneration(env: Env, user: { id: string; username: string }, t
   const ownedFullNames = new Set<string>(publicRepos.map((r: any) => r.full_name.toLowerCase()));
   console.log(`[gen] ${user.username}: ${publicRepos.length} repos (incl. forks)`);
 
-  if (publicRepos.length === 0 && !targetWeek) {
-    await saveDispatch(env.DB, env.DISPATCHES, user.id, user.username, "<p>No public repos found.</p>", from, to);
-    return 0;
-  }
-
   // Search for PRs the user authored in ANY repo during the window (catches external contributions)
   const fromISO = from.toISOString().slice(0, 10);
-  const toISO = new Date(to.getTime() - 86400000).toISOString().slice(0, 10);
+  const toISO = to.toISOString().slice(0, 10);
   console.log(`[gen] ${user.username}: searching PRs ${fromISO}..${toISO}`);
   let externalPRs: { fullName: string; items: any[] }[] = [];
   try {
@@ -671,16 +696,26 @@ async function runGeneration(env: Env, user: { id: string; username: string }, t
 
   // fetch repo data in parallel (batches of 5 to avoid rate limits)
   const reposData: RepoData[] = [];
+  let successfulScans = 0;
+  let failedScans = 0;
   for (let i = 0; i < publicRepos.length; i += 5) {
     const batch = publicRepos.slice(i, i + 5);
     console.log(`[gen] ${user.username}: batch ${i}-${i+batch.length}`);
-    const results = await Promise.all(
+    const results = await Promise.allSettled(
       batch.map((repo: any) => getRepoData(
         user.username, repo.name, from, to, env.GITHUB_TOKEN, npUrl, npSecret,
         repo.fork, repo.fork ? user.username : undefined,
       ))
     );
-    reposData.push(...results.filter((r): r is RepoData => r !== null));
+    results.forEach((result, index) => {
+      if (result.status === "fulfilled") {
+        successfulScans++;
+        if (result.value) reposData.push(result.value);
+      } else {
+        failedScans++;
+        console.error(`failed to scan ${batch[index].name}:`, result.reason);
+      }
+    });
   }
 
   // Add external repos where the user authored PRs
@@ -706,17 +741,26 @@ async function runGeneration(env: Env, user: { id: string; username: string }, t
       });
     } catch (err) { console.warn(`external repo ${fullName} failed:`, err); }
   }
-  console.log(`[gen] ${user.username}: ${reposData.length} active repos total`);
+  console.log(`[gen] ${user.username}: ${reposData.length} active repos, ${failedScans} scan failures`);
 
-  if (reposData.length === 0) {
-    await saveDispatch(env.DB, env.DISPATCHES, user.id, user.username, "<p>No activity this week.</p>", from, to);
-    return 0;
+  if (publicRepos.length > 0 && successfulScans === 0) {
+    throw new Error(`GitHub scan failed for all ${failedScans} repositories`);
   }
 
-  // generate LLM copy
-  console.log(`[gen] ${user.username}: calling LLM`);
-  const copy = await generateCopy(reposData, from, to, user.username, env.OPENROUTER_API_KEY);
-  console.log(`[gen] ${user.username}: LLM done`);
+  let copy: any;
+  const slowNews = reposData.length === 0;
+  if (slowNews) {
+    console.log(`[gen] ${user.username}: publishing slow-news edition`);
+    copy = slowNewsCopy(user.username);
+  } else {
+    // generate and validate LLM copy before spending money on illustrations
+    console.log(`[gen] ${user.username}: calling LLM`);
+    copy = validateGeneratedCopy(
+      await generateCopy(reposData, from, to, user.username, env.OPENROUTER_API_KEY),
+      reposData,
+    );
+    console.log(`[gen] ${user.username}: LLM done`);
+  }
 
   // Enforce total image budget (2-3 pics, always at least 2 AI). Each article gets AT MOST its own
   // unique image — if the LLM wrote multiple articles per repo, only one gets a picture.
@@ -774,6 +818,7 @@ async function runGeneration(env: Env, user: { id: string; username: string }, t
   // build HTML
   const wk = weekKey(to);
   const html = buildHtml(copy, reposData, user.username, from, to, wk);
+  assertPublishableDispatch(html);
 
   // save
   console.log(`[gen] ${user.username}: saving dispatch wk=${wk}`);

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { getUser } from "./auth";
+import { isLegacyEmptyDispatch, slowNewsFragment } from "./dispatch-health";
 import type { Env } from "./index";
 
 export const pageRoutes = new Hono<{ Bindings: Env }>();
@@ -228,7 +229,12 @@ async function fetchAndServeDispatch(
   // Bump ILLUS_V when illustrations are batch-reprocessed (e.g. transparency fixes)
   const ILLUS_V = 2;
   const rawHtml: string = await r2obj.text();
-  const html = rawHtml.replace(
+  // Old zero-activity generations were published as a bare paragraph. Repair
+  // them at read time so historical links become useful without an R2 migration.
+  const recoveredHtml = isLegacyEmptyDispatch(rawHtml)
+    ? slowNewsFragment(username)
+    : rawHtml;
+  const html = recoveredHtml.replace(
     /((?:src|data-img)=["'])((?:https:\/\/gitzette\.online)?\/img\/[^"'?]+)(["'])/g,
     `$1$2?v=${generated_at}.${ILLUS_V}$3`
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/auth.ts",
+    "src/dispatch-health.ts",
+    "src/generate.ts",
+    "src/index.ts",
+    "src/pages.ts",
+    "src/quota.ts"
+  ]
+}


### PR DESCRIPTION
## Goal

Prevent GitZette from publishing empty newspapers and repair the blank editions already visible on the live site.

Fixes #37.

## What changed

- Generate a designed “quiet week” edition when a user has no qualifying public activity instead of storing a bare `<p>No activity this week.</p>` page.
- Repair legacy empty R2 payloads at read time, so existing summer links render the fallback immediately after deploy.
- Distinguish genuine zero activity from total GitHub API failure; an outage now fails generation instead of publishing a false empty edition.
- Tolerate unavailable optional GitHub endpoints and count commits authored by the selected user.
- Validate LLM articles and final HTML before publication.
- Do not charge quota or budget for failed generations.
- Fix past-week regeneration writing the result under the following week.
- Make CI actually enforce Worker type-checking and run the new regression tests.

## How to verify

```bash
bun install
bunx tsc --noEmit
bun test
npx wrangler deploy --dry-run
```

Expected: 5 tests pass, TypeScript exits 0, and Wrangler builds the Worker bundle.

After deploy, these historical pages should show a designed quiet-week edition rather than a bare paragraph:

- https://gitzette.online/dpavlin/2026-W23
- https://gitzette.online/siddharthgoyal00/2026-W22
- https://gitzette.online/pendolf/2026-W24
- https://gitzette.online/vladsimachkov/2026-W24

## Screenshots / before-after

Before: the affected pages contain only “No activity this week.”

After: the normal GitZette shell contains a “The Repositories Observe a Moment of Silence” quiet-week article, zeroed stats, and a deterministic ink illustration.
