### PR TITLE
fix: expose semantic article markers

### DIFF
--- a/src/dispatch-health.test.ts
+++ b/src/dispatch-health.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isLegacyEmptyDispatch, slowNewsCopy, slowNewsFragment } from "./dispatch-health";
+import { addArticleMarkers, isLegacyEmptyDispatch, slowNewsCopy, slowNewsFragment } from "./dispatch-health";
 import { assertPublishableDispatch, validateGeneratedCopy } from "./generate";
 
 describe("empty dispatch recovery", () => {
@@ -15,6 +15,12 @@ describe("empty dispatch recovery", () => {
     expect(copy.articles[0].headline).toContain("Moment of Silence");
     expect(copy.articles[0].deck).toContain("@octocat");
     expect(slowNewsFragment("octocat")).toContain("The presses remain ready");
+    expect(slowNewsFragment("octocat")).toContain(`class="article"`);
+  });
+
+  test("adds semantic markers to generated article blocks", () => {
+    const html = `<div style="margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--rule);"><h2>News</h2></div>`;
+    expect(addArticleMarkers(html)).toContain(`<div class="article"`);
   });
 });
 

--- a/src/dispatch-health.ts
+++ b/src/dispatch-health.ts
@@ -7,6 +7,13 @@ export function isLegacyEmptyDispatch(html: string): boolean {
   return LEGACY_EMPTY_DISPATCHES.has(html.trim().toLowerCase());
 }
 
+export function addArticleMarkers(html: string): string {
+  return html.replace(
+    /<div style="margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var\(--rule\);">/g,
+    `<div class="article" style="margin-bottom:32px;padding-bottom:32px;border-bottom:1px solid var(--rule);">`,
+  );
+}
+
 export function slowNewsCopy(username: string) {
   return {
     masthead: "the dispatch",
@@ -27,7 +34,7 @@ export function slowNewsCopy(username: string) {
 export function slowNewsFragment(username: string): string {
   const copy = slowNewsCopy(username);
   const article = copy.articles[0];
-  return `<section style="max-width:760px;margin:0 auto;padding:48px 24px 64px;">
+  return `<section class="article" style="max-width:760px;margin:0 auto;padding:48px 24px 64px;">
     <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;margin-bottom:12px;">${article.tag}</div>
     <h1 style="font-family:'Playfair Display',Georgia,serif;font-size:clamp(32px,8vw,64px);line-height:1.02;margin-bottom:14px;">${article.headline}</h1>
     <p style="font-family:Georgia,serif;font-size:18px;font-style:italic;color:#666;margin-bottom:28px;">${article.deck}</p>

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { getUser } from "./auth";
-import { isLegacyEmptyDispatch, slowNewsFragment } from "./dispatch-health";
+import { addArticleMarkers, isLegacyEmptyDispatch, slowNewsFragment } from "./dispatch-health";
 import type { Env } from "./index";
 
 export const pageRoutes = new Hono<{ Bindings: Env }>();
@@ -234,7 +234,7 @@ async function fetchAndServeDispatch(
   const recoveredHtml = isLegacyEmptyDispatch(rawHtml)
     ? slowNewsFragment(username)
     : rawHtml;
-  const html = recoveredHtml.replace(
+  const html = addArticleMarkers(recoveredHtml).replace(
     /((?:src|data-img)=["'])((?:https:\/\/gitzette\.online)?\/img\/[^"'?]+)(["'])/g,
     `$1$2?v=${generated_at}.${ILLUS_V}$3`
   );


### PR DESCRIPTION
## Goal

Make production smoke tests correctly recognize every served newspaper article, including single-article and quiet-week editions.

Follow-up to #61.

## What changed

- Add a semantic `.article` marker to the quiet-week fallback.
- Normalize current Worker-generated article blocks at read time so previously stored one-article editions are observable without regeneration.
- Add regression coverage for both marker paths.

## How to verify

```bash
bunx tsc --noEmit
bun test
npx wrangler deploy --dry-run
```

After deploy:

```bash
bash /home/tars/github/gitzette-dispatch/smoke-test.sh
```

Expected: all homepage links report at least one article.

## Screenshots / before-after

No visual change. Before, single-article pages rendered correctly but monitoring reported zero articles. After, the same markup includes a semantic `.article` class and the smoke test sees it.
