### PR TITLE
fix: recover article-free legacy documents

### DIFF
--- a/src/dispatch-health.test.ts
+++ b/src/dispatch-health.test.ts
@@ -9,6 +9,12 @@ describe("empty dispatch recovery", () => {
     expect(isLegacyEmptyDispatch("<p>A real article.</p>")).toBe(false);
   });
 
+  test("recognizes full documents with a masthead but no articles", () => {
+    expect(isLegacyEmptyDispatch(`<!DOCTYPE html><html><head><style>.article { color: black; }</style></head><body><div class="masthead">the dispatch</div></body></html>`)).toBe(true);
+    expect(isLegacyEmptyDispatch(`<!DOCTYPE html><html><body><h2>Real headline</h2><p>Real body</p></body></html>`)).toBe(false);
+    expect(isLegacyEmptyDispatch(`<!DOCTYPE html><html><body><section class="article">News</section></body></html>`)).toBe(false);
+  });
+
   test("builds a useful slow-news edition", () => {
     const copy = slowNewsCopy("octocat");
     expect(copy.articles).toHaveLength(1);

--- a/src/dispatch-health.ts
+++ b/src/dispatch-health.ts
@@ -4,7 +4,16 @@ const LEGACY_EMPTY_DISPATCHES = new Set([
 ]);
 
 export function isLegacyEmptyDispatch(html: string): boolean {
-  return LEGACY_EMPTY_DISPATCHES.has(html.trim().toLowerCase());
+  const normalized = html.trim().toLowerCase();
+  if (LEGACY_EMPTY_DISPATCHES.has(normalized)) return true;
+
+  // Some early Worker editions contain a complete masthead/stats document but
+  // no article at all. Treat those as empty too; CSS selectors do not count.
+  const isDocument = normalized.startsWith("<!doctype") || normalized.startsWith("<html");
+  if (!isDocument) return false;
+  const hasArticleClass = /class=["'][^"']*\barticle\b[^"']*["']/i.test(html);
+  const hasHeadline = /<h2\b[^>]*>/i.test(html);
+  return !hasArticleClass && !hasHeadline;
 }
 
 export function addArticleMarkers(html: string): string {


### PR DESCRIPTION
## Goal

Repair historical Worker editions that contain a full masthead/stats document but no article body.

Follow-up to #61 and #62.

## What changed

- Detect stored HTML documents with neither an article class nor an `<h2>` headline.
- Serve the designed quiet-week edition for those documents without mutating R2.
- Add regression tests that distinguish empty documents, real headline-based editions, and semantic article containers.

## How to verify

```bash
bunx tsc --noEmit
bun test
npx wrangler deploy --dry-run
```

After deploy, `erenworld/2026-W18` and `steipete/2026-W14` should render the quiet-week story and the production smoke test should pass.

## Screenshots / before-after

Before: masthead and stats, but no article. After: the designed “Repositories Observe a Moment of Silence” fallback. No other edition is visually changed.
